### PR TITLE
Update flake8 URL in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,8 @@ repos:
     rev: 21.6b0
     hooks:
     - id: black
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
     - id: flake8
   - repo: https://github.com/pycqa/pylint


### PR DESCRIPTION
The flake8 pre-commit hook URL has changed (see PyCQA/flake8#1737). This PR makes the needed adjustment to the pre-commit config.