### PR TITLE
Adjust parent recipe identifiers

### DIFF
--- a/Grammarly/Grammarly.jamf.recipe
+++ b/Grammarly/Grammarly.jamf.recipe
@@ -44,7 +44,7 @@
 	<key>MinimumVersion</key>
 	<string>2.0.0</string>
 	<key>ParentRecipe</key>
-	<string>Grammarly.pkg.recipe</string>
+	<string>com.github.homebysix.pkg.Grammarly</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/TimeOut/TimeOut.jamf.recipe
+++ b/TimeOut/TimeOut.jamf.recipe
@@ -44,7 +44,7 @@
 	<key>MinimumVersion</key>
 	<string>2.0.0</string>
 	<key>ParentRecipe</key>
-	<string>TimeOut.pkg.recipe</string>
+	<string>uk.ac.ox.orchard.pkg.TimeOut</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
The previous `ParentRecipe` values were shortnames for recipe files, not identifiers. This adjusts to match recipe convention.